### PR TITLE
Enable GitHub's continuous integration for C

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -1,0 +1,12 @@
+name: Continuous Integration for C
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: make
+      run: make


### PR DESCRIPTION
Travis was having problems compiling the project.
Perhaps GitHub will have better luck.